### PR TITLE
Add sonar.login and sonar.password to fix authentication issue.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
     id 'jacoco'
-    id 'org.sonarqube' version '3.3'
+    id 'org.sonarqube' version '4.0.0.2929'
 }
 
 repositories {
@@ -40,6 +40,8 @@ jacocoTestReport {
 sonarqube {
     properties {
         property 'sonar.host.url', 'http://localhost:9000'
+        property 'sonar.login', 'admin'
+        property 'sonar.password', 'admin'
     }
 }
 


### PR DESCRIPTION
This is needed since SonarQube LTS now uses version `9.9`. 

Fixes #4 